### PR TITLE
added immutable-js support via toMutable function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 Redux DevTools Chart Monitor
 =========================
 
-A chart monitor for [Redux DevTools](https://github.com/gaearon/redux-devtools).  
+A chart monitor for [Redux DevTools](https://github.com/gaearon/redux-devtools).
 It shows a real-time view of the store aka the current state of the app.
+
+:rocket: Now with immutable-js support.
 
 [Demo](http://romseguy.github.io/redux-store-visualizer/) [(Source)](https://github.com/romseguy/redux-store-visualizer)
 
@@ -32,7 +34,7 @@ export default createDevTools(
 
 Then you can render `<DevTools>` to any place inside app or even into a separate popup window.
 
-Alternative, you can use it together with [`DockMonitor`](https://github.com/gaearon/redux-devtools-dock-monitor) to make it dockable.  
+Alternative, you can use it together with [`DockMonitor`](https://github.com/gaearon/redux-devtools-dock-monitor) to make it dockable.
 Consult the [`DockMonitor` README](https://github.com/gaearon/redux-devtools-dock-monitor) for details of this approach.
 
 [Read how to start using Redux DevTools.](https://github.com/gaearon/redux-devtools)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Consult the [`DockMonitor` README](https://github.com/gaearon/redux-devtools-doc
 Name                  | Description
 -------------         | -------------
 `theme`               | Either a string referring to one of the themes provided by [redux-devtools-themes](https://github.com/gaearon/redux-devtools-themes) (feel free to contribute!) or a custom object of the same format. Optional. By default, set to [`'nicinabox'`](https://github.com/gaearon/redux-devtools-themes/blob/master/src/nicinabox.js).
+`invertTheme`         | Boolean value that will invert the colors of the selected theme. Optional. By default, set to `false`
 `select`              | A function that selects the slice of the state for DevTools to show. For example, `state => state.thePart.iCare.about`. Optional. By default, set to `state => state`.
+`hasImmutables`       | Boolean value that will walk state tree and convert immutable-js objects to normal objects so that they can be displayed. Optional. By default, set to `false`
 
 ### License
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "chart"
   ],
   "author": "romseguy",
+  "contributors": [
+    "Cole Chamberlain <cole.chamberlain@gmail.com> (https://github.com/cchamberlain)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/romseguy/redux-devtools-chart-monitor/issues"
@@ -49,6 +52,7 @@
     "d3-state-visualizer": "^1.0.2",
     "deepmerge": "^0.2.10",
     "react-pure-render": "^1.0.2",
-    "redux-devtools-themes": "^1.0.0"
+    "redux-devtools-themes": "^1.0.0",
+    "tomutable": "^0.1.3"
   }
 }

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,7 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { tree } from 'd3-state-visualizer';
-import toMutable from 'tomutable';
 
 const wrapperStyle = {
   width: '100%',
@@ -61,19 +60,15 @@ class Chart extends Component {
     })
   };
 
-  constructor(props) {
-    super(props);
-  }
-
   componentDidMount() {
     const { select, state } = this.props;
     this.renderChart = tree(findDOMNode(this), this.props);
-    this.renderChart(select(toMutable(state)));
+    this.renderChart(select(state));
   }
 
   componentWillReceiveProps(nextProps) {
     const { state, select } = nextProps;
-    this.renderChart(select(toMutable(state)));
+    this.renderChart(select(state));
   }
 
   render() {

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,6 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { tree } from 'd3-state-visualizer';
+import toMutable from 'tomutable';
 
 const wrapperStyle = {
   width: '100%',
@@ -67,12 +68,12 @@ class Chart extends Component {
   componentDidMount() {
     const { select, state } = this.props;
     this.renderChart = tree(findDOMNode(this), this.props);
-    this.renderChart(select(state));
+    this.renderChart(select(toMutable(state)));
   }
 
   componentWillReceiveProps(nextProps) {
     const { state, select } = nextProps;
-    this.renderChart(select(state));
+    this.renderChart(select(toMutable(state)));
   }
 
   render() {

--- a/src/ChartMonitor.js
+++ b/src/ChartMonitor.js
@@ -103,11 +103,11 @@ class ChartMonitor extends Component {
     }
 
     if (typeof themes[theme] !== 'undefined') {
-      return invertTheme ? invertColors(themes[theme]) : theme;
+      return invertTheme ? invertColors(themes[theme]) : themes[theme];
     }
 
     console.warn('DevTools theme ' + theme + ' not found, defaulting to nicinabox');
-    return invertTheme ? invertColors(themes.nicinabox) : theme;
+    return invertTheme ? invertColors(themes.nicinabox) : themes.nicinabox;
   }
 
   getChartStyle() {


### PR DESCRIPTION
Love this dev-tool, IMHO it is the most useful one yet.

Only problem for me is that I'm converting my state tree to use immutable-js and as soon as it hits a node in state tree that is immutable, the chart will not show the contents of the node or any of its children, instead it just says "error": "not-serializable". It also throws a bunch of warnings in the console about using size instead of length property on immutable objects is deprecated and will throw in future releases of immutable-js.  I wrote a simple recursive function to walk the state tree, check if any of the objects are immutable, and if so convert them to plain objects. If it finds no immutables in state it will simply return equivalent simple state.

The toMutable function can be found [here](https://github.com/cchamberlain/tomutable)

What I see with the vanilla library when I try to inspect an immutable object:

![image](https://cloud.githubusercontent.com/assets/424694/12766542/46c8127e-c9b9-11e5-8921-9afb363191a0.png)

What I see with the toMutable support added:

![image](https://cloud.githubusercontent.com/assets/424694/12766595/7d039ac0-c9b9-11e5-9743-d657e26d78c6.png)

Given immutable-js is very commonly used, I'm submitting this as a pull request. If you are not looking to support immutable, you may disregard and I'll keep the alternate version published at https://www.npmjs.com/package/redux-devtools-chart-monitor-immutable

Again, thanks for the awesome work!
