### PR TITLE
Add support for react >= 15.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "webpack": "^1.11.0"
   },
   "peerDependencies": {
-    "react": "^0.14.3",
-    "react-dom": "^0.14.3",
+    "react": "^0.14.3 || ^15.0.0",
+    "react-dom": "^0.14.3 || ^15.0.0",
     "redux-devtools": "^3.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
This will get rid of the peer dependency nag error when using react 15 on npm v3 and will allow npm v2 users to continue using.
