### PR TITLE
Support not having monitor's reducers included for Redux DevTools Extension

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -71,7 +71,7 @@ class Chart extends Component {
   componentWillReceiveProps(nextProps) {
     const { state, select, monitorState } = nextProps;
 
-    if (monitorState.isVisible) {
+    if (monitorState.isVisible !== false) {
       this.renderChart(select(state));
     }
   }


### PR DESCRIPTION
So, it will work also when `monitorState.isVisible` is `undefined`.

Related to https://github.com/zalmoxisus/redux-devtools-extension/issues/92.
