### PR TITLE
Support React 15.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "d3-state-visualizer": "^1.1.0",
     "deepmerge": "^0.2.10",
+    "prop-types": "^15.5.8",
     "react-pure-render": "^1.0.2",
     "redux-devtools-themes": "^1.0.0"
   }

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import { tree } from 'd3-state-visualizer';
 

--- a/src/ChartMonitor.js
+++ b/src/ChartMonitor.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import shouldPureComponentUpdate from 'react-pure-render/function';
 import * as themes from 'redux-devtools-themes';
 import { ActionCreators } from 'redux-devtools';


### PR DESCRIPTION
Fixes the warning about accessing PropTypes via the main React package, which is deprecated. Related to https://github.com/gaearon/redux-devtools/issues/359