### PR TITLE
Update all romseguy/ urls to reduxjs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # Change Log
 
 This project adheres to [Semantic Versioning](http://semver.org/).  
-Important releases are documented on the Github [Releases](https://github.com/romseguy/redux-devtools-chart-monitor/releases) page.
+Important releases are documented on the Github [Releases](https://github.com/reduxjs/redux-devtools-chart-monitor/releases) page.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Consult the [`DockMonitor` README](https://github.com/gaearon/redux-devtools-doc
 
 #### ChartMonitor props
 
-You can read the React component [propTypes](https://github.com/romseguy/redux-devtools-chart-monitor/blob/master/src/Chart.js#L11) in addition to the details below:
+You can read the React component [propTypes](https://github.com/reduxjs/redux-devtools-chart-monitor/blob/master/src/Chart.js#L11) in addition to the details below:
 
 Name                  | Description
 -------------         | -------------

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/romseguy/redux-devtools-chart-monitor.git"
+    "url": "https://github.com/reduxjs/redux-devtools-chart-monitor.git"
   },
   "keywords": [
     "redux",
@@ -23,9 +23,9 @@
   "author": "romseguy",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/romseguy/redux-devtools-chart-monitor/issues"
+    "url": "https://github.com/reduxjs/redux-devtools-chart-monitor/issues"
   },
-  "homepage": "https://github.com/romseguy/redux-devtools-chart-monitor",
+  "homepage": "https://github.com/reduxjs/redux-devtools-chart-monitor",
   "devDependencies": {
     "babel-cli": "^6.3.15",
     "babel-core": "^6.1.20",


### PR DESCRIPTION
Small house keeping PR to update CHANGELOG, README, and package.json urls to `reduxjs/`. GitHub does a good job and auto-redirects, but this breaks some automated tooling I use that doesn't follow redirects 🤷‍♂️.

I did a find replace on all instances of `github.com/romseguy/redux-devtools-chart-monitor` in the codebase. 

Please let me know if I missed anything or need to contribute a CHANGELOG entry.